### PR TITLE
Post August patch

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.IO;
 using System.Windows.Forms;
 using System.Collections.Generic;
+using System.Linq;
 
 
 namespace Resonite_DataTree_Converter
@@ -144,13 +145,39 @@ namespace Resonite_DataTree_Converter
             if (dataTreeConverter == null)
             {
                 Console.WriteLine("ERROR: DataTreeConverter not found in Elements.Core");
-                Console.WriteLine("Available types containing 'DataTree' or 'Converter':");
-                foreach (var type in ElementsCore.GetTypes())
+                Console.WriteLine("Attempting to list available types...");
+                try
                 {
-                    if (type.FullName.Contains("DataTree") || type.FullName.Contains("Converter"))
+                    Type[] types = null;
+                    try
                     {
-                        Console.WriteLine($"  - {type.FullName}");
+                        types = ElementsCore.GetTypes();
                     }
+                    catch (ReflectionTypeLoadException ex)
+                    {
+                        // Some types may not load, but we can still get the ones that did
+                        types = ex.Types.Where(t => t != null).ToArray();
+                        Console.WriteLine($"Warning: Some types could not be loaded due to missing dependencies");
+                    }
+                    
+                    if (types != null && types.Length > 0)
+                    {
+                        Console.WriteLine("Available types containing 'DataTree' or 'Converter':");
+                        foreach (var type in types)
+                        {
+                            if (type != null && type.FullName != null && 
+                                (type.FullName.Contains("DataTree") || type.FullName.Contains("Converter")))
+                            {
+                                Console.WriteLine($"  - {type.FullName}");
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Could not enumerate types: {ex.Message}");
+                    Console.WriteLine("\nThis might be due to .NET version mismatch.");
+                    Console.WriteLine("Resonite may be using .NET 9.0 while this converter uses .NET 8.0");
                 }
                 Console.WriteLine("\nPress any key to continue...");
                 Console.ReadKey();

--- a/Program.cs
+++ b/Program.cs
@@ -131,8 +131,46 @@ namespace Resonite_DataTree_Converter
                 return false;
             }
             libraries.TryGetValue("Elements.Core", out Assembly ElementsCore);
+            if (ElementsCore == null)
+            {
+                Console.WriteLine("ERROR: Elements.Core assembly not loaded properly");
+                return false;
+            }
+            
+            // List all types in Elements.Core to help debug
+            Console.WriteLine("Searching for DataTreeConverter in Elements.Core...");
             var dataTreeConverter = ElementsCore.GetType("Elements.Core.DataTreeConverter");
+            
+            if (dataTreeConverter == null)
+            {
+                Console.WriteLine("ERROR: DataTreeConverter not found in Elements.Core");
+                Console.WriteLine("Available types containing 'DataTree' or 'Converter':");
+                foreach (var type in ElementsCore.GetTypes())
+                {
+                    if (type.FullName.Contains("DataTree") || type.FullName.Contains("Converter"))
+                    {
+                        Console.WriteLine($"  - {type.FullName}");
+                    }
+                }
+                Console.WriteLine("\nPress any key to continue...");
+                Console.ReadKey();
+                return false;
+            }
+            
             var dataTreeLoad = dataTreeConverter.GetMethod("Load", new Type[] { typeof(string), typeof(string) });
+            if (dataTreeLoad == null)
+            {
+                Console.WriteLine("ERROR: Load method not found in DataTreeConverter");
+                Console.WriteLine("Available methods:");
+                foreach (var method in dataTreeConverter.GetMethods(BindingFlags.Public | BindingFlags.Static))
+                {
+                    Console.WriteLine($"  - {method.Name}");
+                }
+                Console.WriteLine("\nPress any key to continue...");
+                Console.ReadKey();
+                return false;
+            }
+            
             object convert = dataTreeLoad.Invoke(null, new object[] { ofd.FileName, null });
             //DataTreeDictionary convert = DataTreeConverter.Load(ofd.FileName);
 

--- a/Resonite DataTree Converter.csproj
+++ b/Resonite DataTree Converter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>Resonite_DataTree_Converter</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
There is a bit of excessive code that exist to maintain cross compatibility with pre/post august. Main changes were the new dll locations, and having the converter target NET 9.0 